### PR TITLE
Add admin last login page

### DIFF
--- a/src/main/java/com/luv2code/springboot/demosecurity/Dtos/UserLastLoginDto.java
+++ b/src/main/java/com/luv2code/springboot/demosecurity/Dtos/UserLastLoginDto.java
@@ -1,0 +1,8 @@
+package com.luv2code.springboot.demosecurity.Dtos;
+
+import java.time.LocalDateTime;
+
+public interface UserLastLoginDto {
+    String getUsername();
+    LocalDateTime getLastLogin();
+}

--- a/src/main/java/com/luv2code/springboot/demosecurity/Repositories/LoginActivityRepository.java
+++ b/src/main/java/com/luv2code/springboot/demosecurity/Repositories/LoginActivityRepository.java
@@ -1,7 +1,13 @@
 package com.luv2code.springboot.demosecurity.Repositories;
 
 import com.luv2code.springboot.demosecurity.Entity.LoginActivity;
+import com.luv2code.springboot.demosecurity.Dtos.UserLastLoginDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import java.util.List;
 
 public interface LoginActivityRepository extends JpaRepository<LoginActivity,Long> {
+
+    @Query("SELECT la.username AS username, MAX(la.loginTime) AS lastLogin FROM LoginActivity la GROUP BY la.username")
+    List<UserLastLoginDto> findLastLoginTimes();
 }

--- a/src/main/java/com/luv2code/springboot/demosecurity/controller/AdminController.java
+++ b/src/main/java/com/luv2code/springboot/demosecurity/controller/AdminController.java
@@ -1,0 +1,26 @@
+package com.luv2code.springboot.demosecurity.controller;
+
+import com.luv2code.springboot.demosecurity.Dtos.UserLastLoginDto;
+import com.luv2code.springboot.demosecurity.Repositories.LoginActivityRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@Controller
+public class AdminController {
+
+    private final LoginActivityRepository loginActivityRepository;
+
+    public AdminController(LoginActivityRepository loginActivityRepository) {
+        this.loginActivityRepository = loginActivityRepository;
+    }
+
+    @GetMapping("/last-logins")
+    public String showLastLogins(Model model) {
+        List<UserLastLoginDto> logins = loginActivityRepository.findLastLoginTimes();
+        model.addAttribute("logins", logins);
+        return "last-logins";
+    }
+}

--- a/src/main/java/com/luv2code/springboot/demosecurity/security/DemoSecurityConfig.java
+++ b/src/main/java/com/luv2code/springboot/demosecurity/security/DemoSecurityConfig.java
@@ -43,6 +43,7 @@ public class DemoSecurityConfig {
                                 .requestMatchers("/").hasRole("EMPLOYEE")
                                 .requestMatchers("/leaders/**").hasRole("MANAGER")
                                 .requestMatchers("/systems/**").hasRole("ADMIN")
+                                .requestMatchers("/last-logins").hasRole("ADMIN")
                                 .requestMatchers("/register").permitAll()
                                 .anyRequest().authenticated()
                 )

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -143,6 +143,9 @@
         <a th:href="@{/systems}">💻 IT Systems Meeting</a><br>
         <small>(Only for Admin peeps)</small>
     </p>
+    <p>
+        <a th:href="@{/last-logins}">📈 User Last Logins</a>
+    </p>
     </div>
 
     <hr>

--- a/src/main/resources/templates/last-logins.html
+++ b/src/main/resources/templates/last-logins.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>User Last Logins</title>
+</head>
+<body>
+<h2>User Last Logins</h2>
+<table border="1">
+    <tr>
+        <th>Username</th>
+        <th>Last Login</th>
+    </tr>
+    <tr th:each="log : ${logins}">
+        <td th:text="${log.username}"></td>
+        <td th:text="${#temporals.format(log.lastLogin, 'yyyy-MM-dd HH:mm:ss')}"></td>
+    </tr>
+</table>
+<br>
+<a th:href="@{/}">Back to Home Page</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add UserLastLoginDto for projection
- expose last login query in LoginActivityRepository
- provide AdminController to show login activity
- secure `/last-logins` endpoint
- add simple admin logins page and link from home

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866dd2709988327a15ca93f55b9a834