### PR TITLE
Improve last logins dashboard

### DIFF
--- a/src/main/resources/templates/last-logins.html
+++ b/src/main/resources/templates/last-logins.html
@@ -1,22 +1,70 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>User Last Logins</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdKKadq2F9CUG65" crossorigin="anonymous">
+    <style>
+        body {
+            background: linear-gradient(135deg, #141e30, #243b55);
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            color: #fff;
+        }
+
+        .card {
+            background: rgba(255, 255, 255, 0.1);
+            backdrop-filter: blur(10px);
+            border-radius: 15px;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+        }
+
+        .table {
+            color: #fff;
+        }
+
+        .btn-home {
+            background: linear-gradient(135deg, #00c6ff, #0072ff);
+            border: none;
+        }
+
+        .btn-home:hover {
+            background: linear-gradient(135deg, #0072ff, #00c6ff);
+        }
+    </style>
 </head>
 <body>
-<h2>User Last Logins</h2>
-<table border="1">
-    <tr>
-        <th>Username</th>
-        <th>Last Login</th>
-    </tr>
-    <tr th:each="log : ${logins}">
-        <td th:text="${log.username}"></td>
-        <td th:text="${#temporals.format(log.lastLogin, 'yyyy-MM-dd HH:mm:ss')}"></td>
-    </tr>
-</table>
-<br>
-<a th:href="@{/}">Back to Home Page</a>
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="card shadow-lg p-4">
+                <h2 class="text-center mb-4">📈 User Last Logins</h2>
+                <div class="table-responsive">
+                    <table class="table table-striped table-hover">
+                        <thead>
+                        <tr>
+                            <th>Username</th>
+                            <th>Last Login</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr th:each="log : ${logins}">
+                            <td th:text="${log.username}"></td>
+                            <td th:text="${#temporals.format(log.lastLogin, 'yyyy-MM-dd HH:mm:ss')}"></td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="text-center mt-3">
+                    <a th:href="@{/}" class="btn btn-home">🏠 Back to Home</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- modernize the last-logins dashboard view with Bootstrap styling

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ec484cac8327954e4fc897eac537