### PR TITLE
Revamp front-end with poker assistant branding

### DIFF
--- a/src/main/resources/static/css/poker-theme.css
+++ b/src/main/resources/static/css/poker-theme.css
@@ -1,0 +1,336 @@
+@import url('https://fonts.googleapis.com/css2?family=Cardo:wght@700&family=Play&display=swap');
+
+:root {
+    --poker-red: #7c0f17;
+    --poker-deep-red: #320607;
+    --poker-dark: #080202;
+    --poker-gold: #f6c177;
+    --poker-amber: #d8a24e;
+    --poker-cream: #f8efe3;
+    --poker-muted: #c0a080;
+    --poker-shadow: rgba(0, 0, 0, 0.6);
+}
+
+* {
+    box-sizing: border-box;
+    font-family: 'Play', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+body.poker-table {
+    margin: 0;
+    min-height: 100vh;
+    background: radial-gradient(circle at top, rgba(124, 15, 23, 0.65), var(--poker-deep-red) 55%, var(--poker-dark) 100%);
+    color: var(--poker-cream);
+    position: relative;
+    padding-bottom: 40px;
+}
+
+body.poker-table::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background-image: radial-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+                      radial-gradient(rgba(0, 0, 0, 0.15) 1px, transparent 1px);
+    background-size: 40px 40px;
+    background-position: 0 0, 20px 20px;
+    opacity: 0.35;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.poker-header {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.5rem 8vw;
+    background: rgba(8, 2, 2, 0.75);
+    border-bottom: 1px solid rgba(246, 193, 119, 0.5);
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.65);
+    backdrop-filter: blur(6px);
+}
+
+.poker-brand {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.poker-brand img {
+    width: 72px;
+    height: 72px;
+}
+
+.poker-brand-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.poker-brand-title {
+    font-family: 'Cardo', serif;
+    font-size: 1.85rem;
+    letter-spacing: 0.15rem;
+    text-transform: uppercase;
+    color: var(--poker-gold);
+}
+
+.poker-brand-subtitle {
+    font-size: 0.85rem;
+    letter-spacing: 0.3rem;
+    text-transform: uppercase;
+    color: rgba(248, 239, 227, 0.75);
+}
+
+.poker-nav {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.poker-nav a,
+.poker-nav button,
+.poker-btn,
+.poker-link-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0.65rem 1.4rem;
+    background: linear-gradient(135deg, rgba(124, 15, 23, 0.9), rgba(50, 6, 7, 0.9));
+    color: var(--poker-cream);
+    border: 1px solid rgba(246, 193, 119, 0.65);
+    border-radius: 999px;
+    cursor: pointer;
+    text-decoration: none;
+    letter-spacing: 0.08rem;
+    font-weight: 600;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
+}
+
+.poker-nav button {
+    background: linear-gradient(135deg, rgba(146, 19, 27, 0.95), rgba(63, 10, 12, 0.95));
+}
+
+.poker-nav a:hover,
+.poker-nav button:hover,
+.poker-btn:hover,
+.poker-link-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.55);
+    background: linear-gradient(135deg, rgba(246, 193, 119, 0.9), rgba(124, 15, 23, 0.95));
+    color: var(--poker-dark);
+}
+
+.poker-link-btn {
+    align-self: flex-end;
+    background: rgba(124, 15, 23, 0.3);
+    border-style: dashed;
+    border-color: rgba(246, 193, 119, 0.4);
+    padding: 0.4rem 1.1rem;
+}
+
+.poker-link-btn:hover {
+    background: rgba(246, 193, 119, 0.8);
+    color: var(--poker-dark);
+}
+
+main.poker-main,
+.poker-main {
+    position: relative;
+    z-index: 1;
+    width: min(1100px, 90vw);
+    margin: 3rem auto;
+}
+
+.poker-card {
+    background: rgba(12, 4, 4, 0.82);
+    border-radius: 24px;
+    border: 1px solid rgba(246, 193, 119, 0.6);
+    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.6);
+    padding: 2.5rem;
+    backdrop-filter: blur(10px);
+    position: relative;
+    overflow: hidden;
+}
+
+.poker-card::before {
+    content: "";
+    position: absolute;
+    inset: 12px;
+    border: 1px solid rgba(124, 15, 23, 0.35);
+    border-radius: 18px;
+    pointer-events: none;
+}
+
+.poker-card h1,
+.poker-card h2,
+.poker-card h3 {
+    font-family: 'Cardo', serif;
+    color: var(--poker-gold);
+    letter-spacing: 0.1rem;
+    margin-bottom: 1.25rem;
+}
+
+.poker-card p,
+.poker-card li,
+.poker-card span,
+.poker-card label {
+    color: rgba(248, 239, 227, 0.9);
+    line-height: 1.6;
+    font-size: 1.05rem;
+}
+
+.poker-input,
+.poker-card input[type="text"],
+.poker-card input[type="password"],
+.poker-card input[type="email"],
+.poker-card select {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border-radius: 12px;
+    border: 1px solid rgba(246, 193, 119, 0.5);
+    background: rgba(20, 5, 5, 0.85);
+    color: var(--poker-cream);
+    margin-bottom: 1.1rem;
+    transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.poker-card input::placeholder {
+    color: rgba(248, 239, 227, 0.55);
+}
+
+.poker-card input:focus,
+.poker-card select:focus {
+    outline: none;
+    border: 1px solid var(--poker-gold);
+    box-shadow: 0 0 0 4px rgba(246, 193, 119, 0.25);
+}
+
+.poker-alert {
+    background: rgba(124, 15, 23, 0.65);
+    border: 1px solid rgba(246, 193, 119, 0.65);
+    padding: 0.85rem 1rem;
+    border-radius: 12px;
+    margin-bottom: 1.2rem;
+    text-align: center;
+    font-weight: 600;
+}
+
+.welcome-banner {
+    border: 1px dashed rgba(246, 193, 119, 0.45);
+    border-radius: 16px;
+    padding: 1rem 1.4rem;
+    margin-bottom: 1.8rem;
+    text-align: center;
+    font-size: 1.05rem;
+    background: rgba(30, 10, 10, 0.65);
+}
+
+.auth-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 4rem 1.5rem;
+}
+
+.auth-card {
+    max-width: 420px;
+    width: 100%;
+    text-align: center;
+}
+
+.auth-card .brand-logo {
+    width: 120px;
+    margin-bottom: 1.25rem;
+}
+
+.auth-card form {
+    margin-top: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.poker-link {
+    color: var(--poker-gold);
+    text-decoration: none;
+}
+
+.poker-link:hover {
+    text-decoration: underline;
+}
+
+.table-dark.poker-table-grid,
+.poker-table-grid {
+    --bs-table-bg: rgba(8, 2, 2, 0.75);
+    --bs-table-striped-color: var(--poker-cream);
+    --bs-table-striped-bg: rgba(124, 15, 23, 0.15);
+    --bs-table-hover-color: var(--poker-cream);
+    --bs-table-hover-bg: rgba(246, 193, 119, 0.1);
+    color: var(--poker-cream);
+}
+
+.dataTables_wrapper .dataTables_filter label,
+.dataTables_wrapper .dataTables_info,
+.dataTables_wrapper .dataTables_paginate {
+    color: var(--poker-cream) !important;
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button {
+    color: var(--poker-cream) !important;
+    border: 1px solid rgba(246, 193, 119, 0.4) !important;
+    background: rgba(30, 10, 10, 0.75) !important;
+    border-radius: 999px;
+    margin: 0 0.2rem;
+}
+
+.dataTables_wrapper .dataTables_paginate .paginate_button.current,
+.dataTables_wrapper .dataTables_paginate .paginate_button:hover {
+    color: var(--poker-dark) !important;
+    background: var(--poker-gold) !important;
+}
+
+.poker-footer {
+    position: relative;
+    z-index: 1;
+    text-align: center;
+    margin-top: 3rem;
+    color: rgba(248, 239, 227, 0.7);
+    font-size: 0.85rem;
+}
+
+@media (max-width: 768px) {
+    .poker-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
+    }
+
+    .poker-nav {
+        width: 100%;
+        justify-content: flex-start;
+    }
+
+    .auth-card {
+        padding: 2rem 1.5rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .poker-brand img {
+        width: 60px;
+        height: 60px;
+    }
+
+    .poker-brand-title {
+        font-size: 1.5rem;
+    }
+
+    .poker-card {
+        padding: 2rem 1.5rem;
+    }
+}

--- a/src/main/resources/static/images/poker-logo.svg
+++ b/src/main/resources/static/images/poker-logo.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="table" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#5a0f14" />
+      <stop offset="100%" stop-color="#1b0405" />
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fff9f2" />
+      <stop offset="100%" stop-color="#ead8c0" />
+    </linearGradient>
+    <linearGradient id="hand" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f9e5cf" />
+      <stop offset="100%" stop-color="#d6b79a" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="12" stdDeviation="12" flood-color="#120506" flood-opacity="0.55" />
+    </filter>
+  </defs>
+
+  <rect width="512" height="512" fill="url(#table)" rx="36" />
+  <g opacity="0.12">
+    <path d="M44 90c30 0 60 20 60 50s-30 50-60 50-60-20-60-50S14 90 44 90z" fill="#9b2d30" />
+    <path d="M468 322c20 0 38 14 38 32s-18 32-38 32-38-14-38-32 18-32 38-32z" fill="#9b2d30" />
+    <path d="M126 404c26 0 48 18 48 40s-22 40-48 40-48-18-48-40 22-40 48-40z" fill="#9b2d30" />
+    <path d="M408 120c18 0 34 12 34 28s-16 28-34 28-34-12-34-28 16-28 34-28z" fill="#9b2d30" />
+  </g>
+
+  <g filter="url(#shadow)">
+    <path d="M121 299c44 18 74 10 104-22l30-32c7-7 17-11 27-10l66 7c11 1 21 7 27 16l12 18c11 17 11 40-1 57-23 32-70 31-98 4l-5-5c-6-6-16-6-22 0-6 6-6 16 0 22 17 17 39 27 62 29 23 1 47-6 66-23 30-27 37-72 16-107l-12-20c-9-15-24-25-41-27l-73-8c-20-2-40 6-54 21l-30 32c-24 26-44 29-76 16-8-3-17 1-20 9-3 8 1 17 9 20z" fill="url(#hand)" />
+    <path d="M368 214c-22-28-56-40-87-31l-36 11c-10 3-18 9-24 18l-20 31c-5 8-5 19 2 26 8 9 21 9 30 1l42-40c6-6 16-6 22 0s6 16 0 22l-20 20c-7 7-7 18 0 25 7 7 18 7 25 0l18-18c7-7 19-7 26 1 7 8 6 19-1 26l-22 22c-6 6-6 16 0 22 6 6 16 6 22 0l32-32c22-22 24-56 5-80z" fill="url(#hand)" />
+  </g>
+
+  <g transform="translate(230 135) rotate(-12)">
+    <rect x="-70" y="-110" width="140" height="190" rx="14" fill="url(#card)" stroke="#c0a080" stroke-width="6" />
+    <rect x="-120" y="-90" width="140" height="190" rx="14" fill="url(#card)" stroke="#c0a080" stroke-width="6" />
+    <rect x="-20" y="-90" width="140" height="190" rx="14" fill="url(#card)" stroke="#c0a080" stroke-width="6" />
+    <g transform="translate(-30,-70)">
+      <text x="0" y="0" font-family="Cardo, serif" font-size="36" fill="#7c0f17" font-weight="700">A</text>
+      <path d="M18 20c18-20 38-20 56 0 18 20 0 46-28 70-28-24-46-50-28-70z" fill="#c22034" />
+      <text x="78" y="140" font-family="Cardo, serif" font-size="36" fill="#7c0f17" font-weight="700" transform="rotate(180 78 140)">A</text>
+    </g>
+    <g transform="translate(30,-50)">
+      <text x="0" y="0" font-family="Cardo, serif" font-size="36" fill="#7c0f17" font-weight="700">A</text>
+      <path d="M18 20c18-20 38-20 56 0 18 20 0 46-28 70-28-24-46-50-28-70z" fill="#c22034" />
+      <text x="78" y="140" font-family="Cardo, serif" font-size="36" fill="#7c0f17" font-weight="700" transform="rotate(180 78 140)">A</text>
+    </g>
+  </g>
+
+  <text x="256" y="452" text-anchor="middle" font-family="Cardo, serif" font-size="56" fill="#f6c177" letter-spacing="0.22em">POKER</text>
+  <text x="256" y="492" text-anchor="middle" font-family="Play, sans-serif" font-size="30" fill="#f8efe3" letter-spacing="0.45em">ASSISTANT</text>
+</svg>

--- a/src/main/resources/templates/access-denied.html
+++ b/src/main/resources/templates/access-denied.html
@@ -3,136 +3,37 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>🚫 Access Denied - Michalis 🚫</title>
-    <style>
-        /* General Reset */
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-        }
-
-        /* Background Styling */
-        body {
-            background: linear-gradient(135deg, #141e30, #243b55);
-            color: #ffffff;
-            min-height: 100vh;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            padding: 20px;
-            overflow: hidden;
-        }
-
-        /* Glassmorphism Card */
-        .access-denied-container {
-            background: rgba(255, 255, 255, 0.1);
-            backdrop-filter: blur(10px);
-            padding: 40px 50px;
-            border-radius: 20px;
-            text-align: center;
-            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-            max-width: 420px;
-            width: 100%;
-            animation: fadeIn 1.5s ease-in-out;
-            border: 1px solid rgba(255, 255, 255, 0.2);
-        }
-
-        /* Heading */
-        h2 {
-            font-size: 2rem;
-            margin-bottom: 20px;
-            line-height: 1.6;
-            color: #f9d423;
-            animation: slideDown 1s ease;
-        }
-
-        /* Divider */
-        hr {
-            border: none;
-            height: 2px;
-            background: #f9d423;
-            margin: 20px 0;
-            width: 80%;
-            margin-left: auto;
-            margin-right: auto;
-        }
-
-        /* Button-like Link */
-        a {
-            display: inline-block;
-            padding: 14px 30px;
-            background: linear-gradient(45deg, #ff4e50, #f9d423);
-            color: white;
-            text-decoration: none;
-            border-radius: 30px;
-            transition: all 0.4s ease;
-            font-weight: bold;
-            letter-spacing: 1px;
-            position: relative;
-            overflow: hidden;
-        }
-
-        /* Hover & Click Effects */
-        a:hover {
-            background: linear-gradient(45deg, #f9d423, #ff4e50);
-            color: black;
-            transform: translateY(-3px) scale(1.05);
-            box-shadow: 0 8px 20px rgba(249, 212, 35, 0.7);
-        }
-
-        a:active {
-            transform: scale(0.98);
-        }
-
-        /* Animations */
-        @keyframes fadeIn {
-            from { opacity: 0; transform: translateY(-30px); }
-            to { opacity: 1; transform: translateY(0); }
-        }
-
-        @keyframes slideDown {
-            from { transform: translateY(-50px); opacity: 0; }
-            to { transform: translateY(0); opacity: 1; }
-        }
-
-        /* Responsive Design */
-        @media (max-width: 480px) {
-            h2 {
-                font-size: 1.6rem;
-            }
-
-            .access-denied-container {
-                padding: 20px;
-            }
-
-            a {
-                padding: 12px 20px;
-            }
-        }
-    </style>
+    <title>Poker Assistant | Access Denied</title>
+    <link rel="stylesheet" th:href="@{/css/poker-theme.css}">
 </head>
-<body>
+<body class="poker-table">
+<header class="poker-header">
+    <div class="poker-brand">
+        <img src="/images/poker-logo.svg" alt="Poker Assistant logo" loading="lazy">
+        <div class="poker-brand-text">
+            <span class="poker-brand-title">Poker Assistant</span>
+            <span class="poker-brand-subtitle">by Michalis Anastasiadis</span>
+        </div>
+    </div>
+    <nav class="poker-nav">
+        <a th:href="@{/}">🏠 Lobby</a>
+        <a th:href="@{/showMyLoginPage}">🔐 Login</a>
+    </nav>
+</header>
 
-<div class="access-denied-container">
-    <h2> Access Denied <br>You are not authorized to access this resource.</h2>
-    <hr>
-    <a th:href="@{/}" id="backButton">🔙 Back to Home Page</a>
-</div>
+<main class="poker-main">
+    <section class="poker-card" style="text-align: center;">
+        <h2>Access denied</h2>
+        <p>You tried to sit at a reserved table. Please choose a different game or contact the pit boss.</p>
+        <div style="margin-top: 1.8rem; display: flex; justify-content: center; gap: 1rem; flex-wrap: wrap;">
+            <a th:href="@{/}" class="poker-btn">Return to lobby</a>
+            <a th:href="@{/showMyLoginPage}" class="poker-btn">Switch player</a>
+        </div>
+    </section>
+</main>
 
-<script>
-    // Simple JavaScript for fun
-    document.addEventListener("DOMContentLoaded", () => {
-        console.log("Welcome to the Access Denied page! 🚀");
-
-        const backButton = document.getElementById('backButton');
-
-        backButton.addEventListener('click', () => {
-            alert("Taking you back to safety! 🏠");
-        });
-    });
-</script>
-
+<footer class="poker-footer">
+    Poker Assistant keeps every hand fair and secure.
+</footer>
 </body>
 </html>

--- a/src/main/resources/templates/fancy-login.html
+++ b/src/main/resources/templates/fancy-login.html
@@ -1,174 +1,63 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>🔐 Login - Michalis Portal</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
-    <style>
-        * {
-            box-sizing: border-box;
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-        }
-
-        body {
-            background: linear-gradient(135deg, #141e30, #243b55);
-            min-height: 100vh;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            padding: 20px;
-        }
-
-        .card {
-            background: rgba(255, 255, 255, 0.15);
-            backdrop-filter: blur(10px);
-            border-radius: 15px;
-            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-            padding: 20px;
-            width: 100%;
-            max-width: 400px;
-            animation: fadeIn 1.5s ease-in-out;
-            color: #fff;
-            border: 1px solid rgba(255, 255, 255, 0.2);
-        }
-
-        .card-header {
-            background: linear-gradient(135deg, #00c6ff, #0072ff);
-            color: white;
-            font-weight: bold;
-            text-align: center;
-            font-size: 1.5rem;
-            border-radius: 10px 10px 0 0;
-            padding: 15px;
-        }
-
-        .form-control {
-            background: rgba(255, 255, 255, 0.2);
-            border: none;
-            color: white;
-        }
-
-        .form-control:focus {
-            background: rgba(255, 255, 255, 0.3);
-            border: 1px solid #00c6ff;
-            box-shadow: none;
-            color: white;
-        }
-
-        ::placeholder {
-            color: rgba(255, 255, 255, 0.7);
-        }
-
-        .btn-success {
-            background: linear-gradient(135deg, #00c6ff, #0072ff);
-            border: none;
-            transition: all 0.3s ease;
-            width: 100%;
-        }
-
-        .btn-success:hover {
-            background: linear-gradient(135deg, #0072ff, #00c6ff);
-            transform: translateY(-3px) scale(1.05);
-            box-shadow: 0 6px 20px rgba(0, 198, 255, 0.7);
-        }
-
-        .btn-register {
-            background: linear-gradient(135deg, #ff416c, #ff4b2b);
-            border: none;
-            transition: all 0.3s ease;
-            width: 100%;
-        }
-
-        .btn-register:hover {
-            background: linear-gradient(135deg, #ff4b2b, #ff416c);
-            transform: translateY(-3px) scale(1.05);
-            box-shadow: 0 6px 20px rgba(255, 75, 43, 0.7);
-        }
-
-        .alert {
-            animation: fadeIn 1s ease-in-out;
-        }
-
-        .toggle-password {
-            cursor: pointer;
-            color: #00c6ff;
-            user-select: none;
-            font-weight: bold;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-                transform: translateY(-30px);
-            }
-
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-    </style>
+    <title>Poker Assistant | Login</title>
+    <link rel="stylesheet" th:href="@{/css/poker-theme.css}">
 </head>
+<body class="poker-table">
+<main class="auth-wrapper">
+    <section class="poker-card auth-card">
+        <img src="/images/poker-logo.svg" alt="Poker Assistant logo" class="brand-logo" loading="lazy">
+        <h1>Poker Assistant</h1>
+        <p class="welcome-banner">&lsquo; Welcome to poker Assistant, an app made by Michalis anastasiadis &rsquo;</p>
+        <p>Place your best hand on the felt and sign in to continue.</p>
 
-<body>
-<div class="container">
-    <div id="loginbox" class="mx-auto">
-        <div class="card">
-            <div class="card-header">
-                🚀 Sign In to Michalis Portal
+        <form th:action="@{/authenticateTheUser}" method="POST" id="loginForm">
+            <div th:if="${param.error}" class="poker-alert">
+                Invalid username or password. Try a new play.
             </div>
-            <div class="card-body">
-                <form th:action="@{/authenticateTheUser}" method="POST" class="form-horizontal" id="loginForm">
-                    <div th:if="${param.error}" class="alert alert-danger text-center">
-                        Invalid username or password.
-                    </div>
-                    <div th:if="${param.logout}" class="alert alert-success text-center">
-                        You have been logged out successfully.
-                    </div>
-                    <div class="mb-3">
-                        <input type="text" name="username" placeholder="Username" class="form-control" required>
-                    </div>
-                    <div class="mb-3 position-relative">
-                        <input type="password" name="password" placeholder="Password" class="form-control" id="password" required>
-                        <small class="toggle-password" onclick="togglePassword()">👁️ Show</small>
-                    </div>
-                    <div>
-                        <button type="submit" class="btn btn-success">Login</button>
-                    </div>
-                </form>
-                <div class="d-grid mt-3">
-                    <a href="/register" class="btn btn-register">Sign Up</a>
-                </div>
+            <div th:if="${param.logout}" class="poker-alert">
+                You have been logged out successfully.
             </div>
+            <label for="username">Username</label>
+            <input id="username" type="text" name="username" placeholder="Dealer name" required>
+
+            <label for="password">Password</label>
+            <input id="password" type="password" name="password" placeholder="Secret passphrase" required>
+            <button type="button" class="poker-link-btn" id="togglePassword">👁 Show cards</button>
+
+            <button type="submit" class="poker-btn">Enter the table</button>
+        </form>
+
+        <div style="margin-top: 1.5rem;">
+            <a href="/register" class="poker-link">Need a seat? Register here.</a>
         </div>
-    </div>
-</div>
+    </section>
+</main>
 
 <script>
-    function togglePassword() {
-        const passwordInput = document.getElementById('password');
-        const toggleBtn = document.querySelector('.toggle-password');
+    const toggle = document.getElementById('togglePassword');
+    const passwordInput = document.getElementById('password');
+    toggle.addEventListener('click', () => {
         if (passwordInput.type === 'password') {
             passwordInput.type = 'text';
-            toggleBtn.textContent = '🙈 Hide';
+            toggle.textContent = '🙈 Hide cards';
         } else {
             passwordInput.type = 'password';
-            toggleBtn.textContent = '👁️ Show';
+            toggle.textContent = '👁 Show cards';
         }
-    }
+    });
 
-    document.getElementById('loginForm').addEventListener('submit', function(event) {
-        const username = document.querySelector('input[name="username"]').value;
-        const password = document.querySelector('input[name="password"]').value;
-        if (username.trim() === '' || password.trim() === '') {
+    document.getElementById('loginForm').addEventListener('submit', (event) => {
+        const username = document.getElementById('username').value.trim();
+        const password = passwordInput.value.trim();
+        if (!username || !password) {
             event.preventDefault();
-            alert('Please fill in both the username and password fields.');
+            alert('Both username and password are required to sit at the table.');
         }
     });
 </script>
 </body>
-
 </html>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,176 +1,73 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
-
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>🏢 Michalis Company Home Page 🏢</title>
-    <style>
-        /* Reset */
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-        }
-
-        /* Body Styling */
-        body {
-            background: linear-gradient(135deg, #1e3c72, #2a5298);
-            color: #ffffff;
-            min-height: 100vh;
-            padding: 20px;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-        }
-
-        /* Container */
-        .container {
-            background: rgba(255, 255, 255, 0.1);
-            backdrop-filter: blur(10px);
-            padding: 30px 40px;
-            border-radius: 15px;
-            text-align: center;
-            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-            max-width: 500px;
-            width: 100%;
-            margin-top: 40px;
-            animation: fadeIn 1.5s ease-in-out;
-            border: 1px solid rgba(255, 255, 255, 0.2);
-        }
-
-        h2 {
-            font-size: 2rem;
-            margin-bottom: 20px;
-            color: #f9d423;
-        }
-
-        p {
-            margin: 15px 0;
-            font-size: 1.1rem;
-            line-height: 1.6;
-        }
-
-        hr {
-            border: none;
-            height: 2px;
-            background: #f9d423;
-            margin: 20px 0;
-            width: 80%;
-            margin-left: auto;
-            margin-right: auto;
-        }
-
-        /* Button & Links Styling */
-        a, input[type="submit"] {
-            display: inline-block;
-            padding: 12px 25px;
-            background: linear-gradient(45deg, #ff4e50, #f9d423);
-            color: white;
-            text-decoration: none;
-            border: none;
-            border-radius: 30px;
-            transition: all 0.3s ease;
-            font-weight: bold;
-            cursor: pointer;
-        }
-
-        a:hover, input[type="submit"]:hover {
-            background: linear-gradient(45deg, #f9d423, #ff4e50);
-            color: black;
-            transform: translateY(-3px) scale(1.05);
-            box-shadow: 0 6px 15px rgba(249, 212, 35, 0.8);
-        }
-
-        a:active, input[type="submit"]:active {
-            transform: scale(0.97);
-        }
-
-        /* Responsive Design */
-        @media (max-width: 480px) {
-            .container {
-                padding: 20px;
-            }
-
-            h2 {
-                font-size: 1.6rem;
-            }
-
-            a, input[type="submit"] {
-                padding: 10px 20px;
-                font-size: 0.9rem;
-            }
-        }
-
-        /* Animations */
-        @keyframes fadeIn {
-            from { opacity: 0; transform: translateY(-20px); }
-            to { opacity: 1; transform: translateY(0); }
-        }
-    </style>
+    <title>Poker Assistant | Lobby</title>
+    <link rel="stylesheet" th:href="@{/css/poker-theme.css}">
 </head>
-
-<body>
-
-<div class="container">
-    <h2>🏢 Michalis Company Home Page 🏢</h2>
-    <hr>
-
-    <p>Welcome to the Michalis company home page!</p>
-
-    <hr>
-
-    <!-- Display user name and role(s) -->
-    <p>
-        👤 <strong>User:</strong> <span sec:authentication="principal.username"></span><br><br>
-        🔐 <strong>Role(s):</strong> <span sec:authentication="principal.authorities"></span>
-    </p>
-
-
-    <div sec:authorize="hasRole('MANAGER')">
-    <!-- Manager Access -->
-        <p>
-            <a th:href="@{/leaders}">👥 Leadership Meeting</a><br>
-            <small>(Only for Manager peeps)</small>
-        </p>
+<body class="poker-table">
+<header class="poker-header">
+    <div class="poker-brand">
+        <img src="/images/poker-logo.svg" alt="Poker Assistant logo" loading="lazy">
+        <div class="poker-brand-text">
+            <span class="poker-brand-title">Poker Assistant</span>
+            <span class="poker-brand-subtitle">by Michalis Anastasiadis</span>
+        </div>
     </div>
+    <nav class="poker-nav">
+        <a th:href="@{/}">🏠 Lobby</a>
+        <a th:href="@{/leaders}" sec:authorize="hasRole('MANAGER')">👑 Leader table</a>
+        <a th:href="@{/systems}" sec:authorize="hasRole('ADMIN')">🛠 Systems vault</a>
+        <a th:href="@{/last-logins}" sec:authorize="hasRole('ADMIN')">📈 Last logins</a>
+        <form th:action="@{/logout}" method="POST" style="margin:0;">
+            <button type="submit">🚪 Leave table</button>
+        </form>
+    </nav>
+</header>
 
-    <div sec:authorize="hasRole('ADMIN')">
-    <!-- Admin Access -->
-    <p>
-        <a th:href="@{/systems}">💻 IT Systems Meeting</a><br>
-        <small>(Only for Admin peeps)</small>
-    </p>
-    <p>
-        <a th:href="@{/last-logins}">📈 User Last Logins</a>
-    </p>
-    </div>
+<main class="poker-main">
+    <section class="poker-card">
+        <h2>Welcome back to the lobby</h2>
+        <p>The chips are stacked and the cards are shuffled. Your personal dashboard keeps every move in sight.</p>
 
-    <hr>
+        <div style="margin-top: 1.5rem;">
+            <p>
+                <strong>👤 Player:</strong> <span sec:authentication="principal.username"></span><br><br>
+                <strong>🎴 Role(s):</strong> <span sec:authentication="principal.authorities"></span>
+            </p>
+        </div>
 
-    <!-- Logout Button -->
-    <form th:action="@{/logout}" method="POST" id="logoutForm">
-        <input type="submit" value="🚪 Logout" />
-    </form>
-</div>
+        <div sec:authorize="hasRole('MANAGER')" style="margin-top: 2rem;">
+            <h3>High roller room</h3>
+            <p>Exclusive briefings for managers await at the leader table.</p>
+            <a th:href="@{/leaders}" class="poker-btn">Enter leader meeting</a>
+        </div>
+
+        <div sec:authorize="hasRole('ADMIN')" style="margin-top: 2rem;">
+            <h3>Control room</h3>
+            <p>Keep watch over systems and player logins.</p>
+            <div style="display: flex; flex-wrap: wrap; gap: 0.75rem;">
+                <a th:href="@{/systems}" class="poker-btn">IT systems vault</a>
+                <a th:href="@{/last-logins}" class="poker-btn">Recent logins</a>
+            </div>
+        </div>
+
+        <div class="welcome-banner" style="margin-top: 2.5rem;">
+            Need another deck? Reach out to Michalis Anastasiadis for new features.
+        </div>
+    </section>
+</main>
+
+<footer class="poker-footer">
+    Enjoy responsible gaming. May the odds be ever in your favour.
+</footer>
 
 <script>
-    // JavaScript for Dynamic Welcome Message and Logout Alert
-    document.addEventListener("DOMContentLoaded", () => {
-        console.log("Welcome to Michalis Company Portal 🚀");
-
-        const logoutForm = document.getElementById("logoutForm");
-
-        logoutForm.addEventListener("submit", (e) => {
-            const confirmLogout = confirm("Are you sure you want to log out? 🔒");
-            if (!confirmLogout) {
-                e.preventDefault(); // Cancel form submission if user clicks "Cancel"
-            }
-        });
+    document.addEventListener('DOMContentLoaded', () => {
+        console.log('Poker Assistant lobby ready.');
     });
 </script>
-
 </body>
 </html>

--- a/src/main/resources/templates/last-logins.html
+++ b/src/main/resources/templates/last-logins.html
@@ -3,60 +3,38 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>User Last Logins Dashboard</title>
-    <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <!-- Font Awesome for icons -->
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" rel="stylesheet">
-    <!-- DataTables CSS -->
-    <link href="https://cdn.datatables.net/1.13.4/css/dataTables.bootstrap5.min.css" rel="stylesheet">
-    <style>
-        body {
-            background: linear-gradient(135deg, #141e30, #243b55);
-            min-height: 100vh;
-            color: #fff;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        .card-transparent {
-            background: rgba(255, 255, 255, 0.05);
-            border: none;
-            backdrop-filter: blur(10px);
-            width: 90vw;
-            max-width: 1200px;
-        }
-        .table-hover tbody tr:hover {
-            background-color: rgba(255, 255, 255, 0.1);
-        }
-        table.dataTable {
-            width: 100% !important;
-        }
-        .table {
-            font-size: 1.25rem;
-        }
-        .dataTables_wrapper .dataTables_filter {
-            text-align: right;
-        }
-        .dataTables_wrapper .dataTables_paginate {
-            text-align: center;
-        }
-    </style>
+    <title>Poker Assistant | Recent Logins</title>
+    <link rel="stylesheet" th:href="@{/css/poker-theme.css}">
+    <link th:href="@{https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css}" rel="stylesheet">
+    <link th:href="@{https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css}" rel="stylesheet">
+    <link th:href="@{https://cdn.datatables.net/1.13.4/css/dataTables.bootstrap5.min.css}" rel="stylesheet">
 </head>
-<body>
-<div class="card card-transparent shadow-lg">
-    <!-- Header -->
-    <div class="card-header bg-primary text-white">
-        <h2 class="mb-0"><i class="fas fa-users me-2"></i>Recent Logins</h2>
+<body class="poker-table">
+<header class="poker-header">
+    <div class="poker-brand">
+        <img src="/images/poker-logo.svg" alt="Poker Assistant logo" loading="lazy">
+        <div class="poker-brand-text">
+            <span class="poker-brand-title">Poker Assistant</span>
+            <span class="poker-brand-subtitle">by Michalis Anastasiadis</span>
+        </div>
     </div>
-    <!-- Body -->
-    <div class="card-body p-0">
-        <div class="table-responsive">
-            <table id="loginsTable" class="table table-striped table-hover table-dark mb-0">
+    <nav class="poker-nav">
+        <a th:href="@{/}">🏠 Lobby</a>
+    </nav>
+</header>
+
+<main class="poker-main">
+    <section class="poker-card" style="padding: 0; overflow: hidden;">
+        <div style="padding: 2rem 2.5rem 1rem 2.5rem; border-bottom: 1px solid rgba(246,193,119,0.4);">
+            <h2 style="margin-bottom: 0.5rem;">Recent player logins</h2>
+            <p>Keep track of who joined the tables and when their last session began.</p>
+        </div>
+        <div class="table-responsive" style="padding: 1.5rem 2.5rem 2rem 2.5rem;">
+            <table id="loginsTable" class="table table-striped table-dark poker-table-grid mb-0">
                 <thead>
                 <tr>
-                    <th>User</th>
-                    <th>Last Login</th>
+                    <th>Player</th>
+                    <th>Last login</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -67,21 +45,23 @@
                 </tbody>
             </table>
         </div>
-    </div>
-    <!-- Footer -->
-    <div class="card-footer bg-transparent text-center">
-        <a th:href="@{/}" class="btn btn-outline-light btn-lg"><i class="fas fa-home me-1"></i>Home</a>
-    </div>
-</div>
+        <div style="padding: 1.5rem 2.5rem 2rem 2.5rem; border-top: 1px solid rgba(246,193,119,0.4); display: flex; justify-content: flex-end;">
+            <a th:href="@{/}" class="poker-btn">Back to lobby</a>
+        </div>
+    </section>
+</main>
 
-<!-- Scripts with Thymeleaf parsing disabled -->
+<footer class="poker-footer">
+    Security first: only the right players take a seat.
+</footer>
+
 <script th:inline="none" src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script th:inline="none" src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script th:inline="none" src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
 <script th:inline="none" src="https://cdn.datatables.net/1.13.4/js/dataTables.bootstrap5.min.js"></script>
 <script th:inline="none">
     document.addEventListener('DOMContentLoaded', function() {
-        $('#loginsTable').DataTable({
+        const table = $('#loginsTable').DataTable({
             pageLength: 10,
             lengthChange: false,
             ordering: false,
@@ -89,12 +69,10 @@
             dom: 'ft<"mt-3"p>'
         });
 
-        // Auto-refresh every 30s
         setInterval(() => {
             fetch('/api/logins')
                 .then(res => res.json())
                 .then(data => {
-                    const table = $('#loginsTable').DataTable();
                     table.clear();
                     data.forEach(log => {
                         table.row.add([

--- a/src/main/resources/templates/leaders.html
+++ b/src/main/resources/templates/leaders.html
@@ -2,31 +2,41 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>luv2code LEADERS Home Page</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Poker Assistant | Leader Table</title>
+    <link rel="stylesheet" th:href="@{/css/poker-theme.css}">
 </head>
-<body>
+<body class="poker-table">
+<header class="poker-header">
+    <div class="poker-brand">
+        <img src="/images/poker-logo.svg" alt="Poker Assistant logo" loading="lazy">
+        <div class="poker-brand-text">
+            <span class="poker-brand-title">Poker Assistant</span>
+            <span class="poker-brand-subtitle">by Michalis Anastasiadis</span>
+        </div>
+    </div>
+    <nav class="poker-nav">
+        <a th:href="@{/}">🏠 Lobby</a>
+    </nav>
+</header>
 
-<h2>luv2code LEADERS Home Page</h2>
+<main class="poker-main">
+    <section class="poker-card">
+        <h2>Leadership high roller briefing</h2>
+        <p>The executive suite is open. Review the strategic moves for our next big tournament.</p>
+        <ul style="margin-top: 1.5rem; padding-left: 1.2rem;">
+            <li>Finalize the annual leadership retreat itinerary.</li>
+            <li>Set targets for team mentorship and coaching sessions.</li>
+            <li>Keep our winning streak by nurturing talent and innovation.</li>
+        </ul>
+        <div style="margin-top: 2rem;">
+            <a th:href="@{/}" class="poker-btn">Back to lobby</a>
+        </div>
+    </section>
+</main>
 
-<hr>
-
-<p>
-  See you in Brazil ... for our annual Leadership retreat!
-  <br>
-  Keep this trip a secret, don't tell the regular employees LOL :-)
-</p>
-
-<hr>
-
-<a th:href="@{/}">Back to Home Page</a>
-
+<footer class="poker-footer">
+    Leaders shape the table; make every decision count.
+</footer>
 </body>
 </html>
-
-
-
-
-
-
-
-

--- a/src/main/resources/templates/plain-login.html
+++ b/src/main/resources/templates/plain-login.html
@@ -1,44 +1,26 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-
 <head>
-    <title>Custom Login Page</title>
-
-    <style>
-		.failed {
-			color: red;
-		}
-	</style>
-
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Poker Assistant | Login</title>
+    <link rel="stylesheet" th:href="@{/css/poker-theme.css}">
 </head>
-
-<body>
-
-<h3>My Custom Login Page</h3>
-
-<form action="#" th:action="@{/authenticateTheUser}"
-           method="POST">
-
-    <!-- Check for login error -->
-
-    <div th:if="${param.error}">
-
-        <i class="failed">Sorry! You entered invalid username/password.</i>
-
-    </div>
-
-    <p>
-        User name: <input type="text" name="username" />
-    </p>
-
-    <p>
-        Password: <input type="password" name="password" />
-    </p>
-
-    <input type="submit" value="Login" />
-
-</form>
-
+<body class="poker-table">
+<main class="auth-wrapper">
+    <section class="poker-card auth-card">
+        <img src="/images/poker-logo.svg" alt="Poker Assistant logo" class="brand-logo" loading="lazy">
+        <h1>Poker Assistant</h1>
+        <p class="welcome-banner">&lsquo; Welcome to poker Assistant, an app made by Michalis anastasiadis &rsquo;</p>
+        <form th:action="@{/authenticateTheUser}" method="POST">
+            <div th:if="${param.error}" class="poker-alert">Sorry! You entered an invalid username or password.</div>
+            <label for="username">Username</label>
+            <input id="username" type="text" name="username" required>
+            <label for="password">Password</label>
+            <input id="password" type="password" name="password" required>
+            <button type="submit" class="poker-btn" style="justify-content: center;">Enter the table</button>
+        </form>
+    </section>
+</main>
 </body>
-
 </html>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -1,129 +1,55 @@
-<!--<!DOCTYPE html>-->
-<!--<html lang="en" xmlns:th="http://www.w3.org/1999/xhtml">-->
-<!--<head>-->
-<!--    <meta charset="UTF-8">-->
-<!--    <meta name="viewport" content="width=device-width, initial-scale=1.0">-->
-<!--    <title>Register</title>-->
-<!--    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">-->
-<!--</head>-->
-<!--<body class="d-flex justify-content-center align-items-center vh-100 bg-light">-->
-<!--<div class="card shadow p-4" style="width: 350px;">-->
-<!--    <h3 class="text-center mb-3">Register</h3>-->
-
-<!--    <form th:action="@{/register}" method="POST" th:object="${user}">-->
-<!--        <div class="mb-3">-->
-<!--            <label class="form-label">Username</label>-->
-<!--            <input type="text" th:field="*{username}" class="form-control" placeholder="Enter username" required>-->
-<!--        </div>-->
-
-<!--        <div class="mb-3">-->
-<!--            <label class="form-label">Password</label>-->
-<!--            <input type="password" th:field="*{password}" class="form-control" placeholder="Enter password" required>-->
-<!--        </div>-->
-
-<!--        <div class="mb-3">-->
-<!--            <label class="form-label">Role</label>-->
-<!--            <select th:field="*{role}" class="form-select">-->
-<!--                <option value="ROLE_EMPLOYEE">Employee</option>-->
-<!--                <option value="ROLE_MANAGER">Manager</option>-->
-<!--                <option value="ROLE_ADMIN">Admin</option>-->
-<!--            </select>-->
-<!--        </div>-->
-
-<!--        <button type="submit" class="btn btn-primary w-100">Register</button>-->
-<!--    </form>-->
-
-<!--    <p class="text-center mt-3">-->
-<!--        Already have an account? <a th:href="@{/showMyLoginPage}">Login</a>-->
-<!--    </p>-->
-<!--</div>-->
-
-<!--<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>-->
-<!--</body>-->
-<!--</html>-->
-
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.w3.org/1999/xhtml">
+<html lang="en" xmlns:th="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Register</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
-    <style>
-        body {
-            background: linear-gradient(135deg, #4b6cb7, #182848);
-            height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .card {
-            border-radius: 12px;
-            border: none;
-            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
-            background: white;
-        }
-
-        .form-control {
-            border-radius: 8px;
-            transition: all 0.3s;
-        }
-
-        .form-control:focus {
-            border-color: #4b6cb7;
-            box-shadow: 0 0 5px rgba(75, 108, 183, 0.5);
-        }
-
-        .btn-primary {
-            background: #4b6cb7;
-            border: none;
-            border-radius: 8px;
-            transition: all 0.3s;
-        }
-
-        .btn-primary:hover {
-            background: #3b5aa3;
-        }
-
-        .text-muted {
-            font-size: 0.9rem;
-        }
-    </style>
+    <title>Poker Assistant | Register</title>
+    <link rel="stylesheet" th:href="@{/css/poker-theme.css}">
 </head>
-<body>
-
-<div class="card shadow p-4" style="width: 380px;">
-    <h3 class="text-center mb-3 text-primary">Create an Account</h3>
-
-    <form th:action="@{/register}" method="POST" th:object="${user}">
-        <div class="mb-3">
-            <label class="form-label">Username</label>
-            <input type="text" th:field="*{username}" class="form-control" placeholder="Enter your username" required>
+<body class="poker-table">
+<header class="poker-header">
+    <div class="poker-brand">
+        <img src="/images/poker-logo.svg" alt="Poker Assistant logo" loading="lazy">
+        <div class="poker-brand-text">
+            <span class="poker-brand-title">Poker Assistant</span>
+            <span class="poker-brand-subtitle">by Michalis Anastasiadis</span>
         </div>
+    </div>
+    <nav class="poker-nav">
+        <a th:href="@{/showMyLoginPage}">🔐 Login</a>
+        <a th:href="@{/}">🏠 Lobby</a>
+    </nav>
+</header>
 
-        <div class="mb-3">
-            <label class="form-label">Password</label>
-            <input type="password" th:field="*{password}" class="form-control" placeholder="Enter a strong password" required>
-        </div>
+<main class="poker-main">
+    <section class="poker-card" style="max-width: 460px; margin: 0 auto;">
+        <h2>Claim your seat</h2>
+        <p>Fill in your details to join the Poker Assistant tables.</p>
 
-        <div class="mb-3">
-            <label class="form-label">Role</label>
-            <select th:field="*{role}" class="form-select">
+        <form th:action="@{/register}" method="POST" th:object="${user}">
+            <label for="username">Username</label>
+            <input id="username" type="text" th:field="*{username}" placeholder="Choose a table name" required>
+
+            <label for="password">Password</label>
+            <input id="password" type="password" th:field="*{password}" placeholder="Create a secret code" required>
+
+            <label for="role">Role</label>
+            <select id="role" th:field="*{role}">
                 <option value="ROLE_EMPLOYEE">Employee</option>
                 <option value="ROLE_MANAGER">Manager</option>
                 <option value="ROLE_ADMIN">Admin</option>
             </select>
-        </div>
 
-        <button type="submit" class="btn btn-primary w-100 py-2">Sign Up</button>
-    </form>
+            <button type="submit" class="poker-btn" style="width: 100%; justify-content: center;">Shuffle me in</button>
+        </form>
 
-    <p class="text-center mt-3 text-muted">
-        Already have an account? <a th:href="@{/showMyLoginPage}" class="text-primary">Login</a>
-    </p>
-</div>
+        <p style="margin-top: 1.5rem;">Already have chips stacked?
+            <a th:href="@{/showMyLoginPage}" class="poker-link">Head back to login</a>.</p>
+    </section>
+</main>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<footer class="poker-footer">
+    Your account keeps your winning streak safe.
+</footer>
 </body>
 </html>

--- a/src/main/resources/templates/systems.html
+++ b/src/main/resources/templates/systems.html
@@ -2,31 +2,41 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>luv2code SYSTEMS Home Page</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Poker Assistant | Systems Vault</title>
+    <link rel="stylesheet" th:href="@{/css/poker-theme.css}">
 </head>
-<body>
+<body class="poker-table">
+<header class="poker-header">
+    <div class="poker-brand">
+        <img src="/images/poker-logo.svg" alt="Poker Assistant logo" loading="lazy">
+        <div class="poker-brand-text">
+            <span class="poker-brand-title">Poker Assistant</span>
+            <span class="poker-brand-subtitle">by Michalis Anastasiadis</span>
+        </div>
+    </div>
+    <nav class="poker-nav">
+        <a th:href="@{/}">🏠 Lobby</a>
+    </nav>
+</header>
 
-<h2>luv2code SYSTEMS Home Page</h2>
+<main class="poker-main">
+    <section class="poker-card">
+        <h2>Systems vault</h2>
+        <p>The tech pit keeps our tournament running flawlessly. Review upcoming maintenance and hush-hush upgrades.</p>
+        <ul style="margin-top: 1.6rem; padding-left: 1.2rem;">
+            <li>Schedule the annual infrastructure health check.</li>
+            <li>Prepare the secure cruise for our elite admins.</li>
+            <li>Maintain secrecy—only trusted crew members allowed.</li>
+        </ul>
+        <div style="margin-top: 2rem;">
+            <a th:href="@{/}" class="poker-btn">Back to lobby</a>
+        </div>
+    </section>
+</main>
 
-<hr>
-
-<p>
-  We have annual holiday Caribbean cruise coming up. Register now!
-  <br>
-  Keep this trip a secret, don't tell the regular employees LOL :-)
-</p>
-
-<hr>
-
-<a th:href="@{/}">Back to Home Page</a>
-
+<footer class="poker-footer">
+    Admins guard the systems, ensuring every shuffle is honest.
+</footer>
 </body>
 </html>
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Summary
- replace all HTML templates with a poker-themed layout that showcases the new Poker Assistant logo and welcome message on every screen
- add a shared poker-theme stylesheet and SVG logo to provide consistent colors, typography, and component styling across the app
- refresh login, home, admin, and error views with thematic copy, navigation, and calls-to-action inspired by poker rooms

## Testing
- mvn spring-boot:run *(fails: unable to download parent POM because Maven Central returned 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d944a125208327ba8047617ede9c5d